### PR TITLE
Default get_cmd_states.py range now includes end of available data

### DIFF
--- a/get_cmd_states.py
+++ b/get_cmd_states.py
@@ -73,7 +73,7 @@ def main():
         print 'ERROR: failed to connect to {0}:{1} server: {2}'.format(opt.dbi, opt.server, msg)
         sys.exit(0)
 
-    start = DateTime(opt.start) if opt.start else DateTime(DateTime() - 10)
+    start = DateTime(opt.start) if opt.start else DateTime() - 10
     db_states_q = """SELECT * from cmd_states
                      WHERE datestop > '%s'""" % (start.date)
     if opt.stop:


### PR DESCRIPTION
If --stop is not defined, the code now puts no end limit on the
cmd_states fetch.  Previously the default --stop was Now, which was
not idea for actual use cases.
