### PR TITLE
Fix namespace conflict on get_states() function; version => 0.08.1

### DIFF
--- a/Chandra/cmd_states/__init__.py
+++ b/Chandra/cmd_states/__init__.py
@@ -1,3 +1,3 @@
 from .cmd_states import *
 from .version import __version__
-from .get_cmd_states import get_states
+from .get_cmd_states import fetch_states

--- a/Chandra/cmd_states/get_cmd_states.py
+++ b/Chandra/cmd_states/get_cmd_states.py
@@ -86,15 +86,15 @@ def get_sql_states(start, stop, dbi, server, user, database):
     return states
 
 
-def get_states(start=None, stop=None, vals=None, allow_identical=False,
+def fetch_states(start=None, stop=None, vals=None, allow_identical=False,
                    dbi='hdf5', server=None, user='aca_read', database='aca'):
     """Get Chandra commanded states over a range of time as a structured array.
 
     Examples::
 
       # Get commanded states using the default HDF5 table
-      >>> from Chandra.cmd_states import get_states
-      >>> states = get_states('2011:100', '2011:101', vals=['obsid', 'simpos'])
+      >>> from Chandra.cmd_states import fetch_states
+      >>> states = fetch_states('2011:100', '2011:101', vals=['obsid', 'simpos'])
       >>> states[['datestart', 'datestop', 'obsid', 'simpos']]
       array([('2011:100:11:53:12.378', '2011:101:00:23:01.434', 13255, 75624),
              ('2011:101:00:23:01.434', '2011:101:00:26:01.434', 13255, 91272),
@@ -102,7 +102,7 @@ def get_states(start=None, stop=None, vals=None, allow_identical=False,
             dtype=[('datestart', '|S21'), ('datestop', '|S21'), ('obsid', '<i8'), ('simpos', '<i8')])
 
       # Get same states from Sybase (25 times slower)
-      >>> states2 = get_states('2011:100', '2011:101', vals=['obsid', 'simpos'], dbi='sybase')
+      >>> states2 = fetch_states('2011:100', '2011:101', vals=['obsid', 'simpos'], dbi='sybase')
       >>> states2 == states
       array([ True,  True,  True], dtype=bool)
 
@@ -149,7 +149,7 @@ def get_states(start=None, stop=None, vals=None, allow_identical=False,
 
 
 def main(main_args=None):
-    """Command line interface to get_states.
+    """Command line interface to fetch_states.
     """
 
     descr = ('Get the Chandra commanded states over a range '
@@ -193,7 +193,7 @@ def main(main_args=None):
                 ordered_vals.append(state_val)
         kwargs['vals'] = ordered_vals
 
-    states = get_states(**kwargs)
+    states = fetch_states(**kwargs)
 
     out = open(outfile, 'w') if outfile else sys.stdout
     out.write(Ska.Numpy.pformat(states))

--- a/Chandra/cmd_states/version.py
+++ b/Chandra/cmd_states/version.py
@@ -14,7 +14,7 @@ NOTE: this code copied from astropy and modified.  Any license restrictions
 therein are applicable.
 """
 
-version = '0.08'
+version = '0.08.1'
 
 _versplit = version.replace('dev', '').split('.')
 major = int(_versplit[0])

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -36,10 +36,10 @@ available via the :ref:`get_cmd_states` tool.  For example::
   2012:121:16:04:07.192 2012:123:11:23:20.985 452189113.376 452345067.169 13847 75624
 
 To access the commanded states database from within a Python script use the
-:func:`~Chandra.cmd_states.get_states` function.  For instance::
+:func:`~Chandra.cmd_states.fetch_states` function.  For instance::
 
-  >>> from Chandra.cmd_states import get_states
-  >>> states = get_states('2011:100', '2011:101')
+  >>> from Chandra.cmd_states import fetch_states
+  >>> states = fetch_states('2011:100', '2011:101')
   >>> states[['datestart', 'datestop', 'obsid', 'simpos']]
   array([('2011:100:11:53:12.378', '2011:101:00:23:01.434', 13255, 75624),
          ('2011:101:00:23:01.434', '2011:101:00:26:01.434', 13255, 91272),
@@ -143,6 +143,10 @@ available for users.
 get_cmds
 ^^^^^^^^^
 .. autofunction:: get_cmds
+
+fetch_states
+^^^^^^^^^^^^^^
+.. autofunction:: fetch_states
 
 get_states
 ^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,5 @@
 from setuptools import setup
+from Chandra.cmd_states.version import version
 setup(name='Chandra.cmd_states',
       author='Tom Aldcroft',
       description=('Functions for creating, manipulating and updating '
@@ -11,7 +12,7 @@ setup(name='Chandra.cmd_states',
                   'Chandra.cmd_states.add_nonload_cmds',
                   'Chandra.cmd_states.version',
                   ],
-      version='0.08',
+      version=version,
       zip_safe=False,
       namespace_packages=['Chandra'],
       packages=['Chandra', 'Chandra.cmd_states'],

--- a/tests/test_get_cmd_states.py
+++ b/tests/test_get_cmd_states.py
@@ -4,7 +4,7 @@ from StringIO import StringIO
 import numpy as np
 import asciitable
 
-from Chandra.cmd_states.get_cmd_states import get_states_cli, get_states
+from Chandra.cmd_states.get_cmd_states import main, fetch_states
 
 # This is taken from the output of
 #  get_cmd_states --start=2010:100 --stop=2010:101 --vals=obsid,simpos,pcad_mode,clocking,power_cmd
@@ -30,12 +30,12 @@ OUT = "\n".join(LINES) + "\n"
 VALS = asciitable.read(LINES, guess=False)
 
 
-def test_get_states_cli():
+def test_get_states_main():
     """Test command line interface to getting commanded states.
     """
     cli_string = "--start=2010:100 --stop=2010:101 --vals=obsid,simpos,pcad_mode,clocking,power_cmd"
     sys.stdout = StringIO()
-    get_states_cli(cli_string.split())
+    main(cli_string.split())
     out = sys.stdout.getvalue()
     sys.stdout = sys.__stdout__
     assert out == OUT
@@ -46,8 +46,8 @@ def test_get_states():
     """
     val_names = "obsid,simpos,pcad_mode,clocking,power_cmd".split(',')
     for dbi in ('sybase', 'hdf5'):
-        states = get_states(start='2010:100', stop='2010:101', dbi=dbi,
-                            vals=val_names)
+        states = fetch_states(start='2010:100', stop='2010:101', dbi=dbi,
+                              vals=val_names)
         for name in states.dtype.names:
             if states[name].dtype.kind == 'f':
                 assert np.allclose(states[name], VALS[name])


### PR DESCRIPTION
The Chandra.cmd_states.get_states() function was being clobbered by::

  from Chandra.cmd_states.get_cmd_states import get_states

in **init**.py.  Fix this by renaming get_cmd_states.get_states to
fetch_states.  Adjust docs and tests according.  Also requires an
update to xija.model.py.

Update version to 0.08.1
