### PR TITLE
More general checking for power commands which turn off video boards

### DIFF
--- a/Chandra/cmd_states/__init__.py
+++ b/Chandra/cmd_states/__init__.py
@@ -2,7 +2,7 @@
 from .cmd_states import *
 from .get_cmd_states import fetch_states
 
-__version__ = '3.13.1'
+__version__ = '3.14'
 
 
 def test(*args, **kwargs):

--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -60,11 +60,13 @@ def decode_power(mnem):
 
     Example::
 
-     >>> decode_power("WSPOW08F3E")
-     {'ccd_count': 5,
-      'ccds': 'I0 I1 I2 I3 S3 ',
-      'fep_count': 5,
-      'feps': '1 2 3 4 5 '}
+    >>> decode_power("WSPOW08F3E")
+    {'ccd_count': 5,
+     'ccds': 'I0 I1 I2 I3 S3 ',
+     'clocking': 0,
+     'fep_count': 5,
+     'feps': '1 2 3 4 5 ',
+     'vid_board': 1}
 
     :param mnem: power command string
 

--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -76,8 +76,8 @@ def decode_power(mnem):
                 'vid_board': 1,
                 'clocking': 0}
 
-    # Special case WSPOW00000 to turn off vid_board
-    if mnem == 'WSPOW00000':
+    # Special case WSPOW000XX to turn off vid_board
+    if mnem.startswith('WSPOW000'):
         fep_info['vid_board'] = 0
 
     # the hex for the commanding is after the WSPOW


### PR DESCRIPTION
A new command has been developed which will turn off the video boards in the ACIS DEA but will turn on three FEPs. This command was developed to leave the ACIS board components partially powered during perigee passages for thermal reasons. 

Since all commands that turn off the video boards start with `"WSPOW000"`, this PR generalizes the logic that turns off the video boards so that any command that fulfills that requirement will set `vid_board = 1`. 

I also fixed the docstring to print out the full contents of the dict returned by `decode_power`. 