### PR TITLE
WSVIDALLDN should set ccd_count = 0

### DIFF
--- a/Chandra/cmd_states/__init__.py
+++ b/Chandra/cmd_states/__init__.py
@@ -2,7 +2,7 @@
 from .cmd_states import *
 from .get_cmd_states import fetch_states
 
-__version__ = '3.14.1'
+__version__ = '3.14.2'
 
 
 def test(*args, **kwargs):

--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -267,7 +267,8 @@ def get_states(state0, cmds, exclude=None):
                 add_trans(clocking=1, power_cmd=tlmsid)
 
             elif tlmsid == 'WSVIDALLDN':
-                add_trans(vid_board=0, power_cmd=tlmsid)
+                add_trans(vid_board=0, ccd_count=0,
+                          power_cmd=tlmsid)
 
             elif tlmsid == 'AA00000000':
                 add_trans(clocking=0, power_cmd=tlmsid)


### PR DESCRIPTION
The ACIS command `WSVIDALLDN` powers down all the video boards, and as such should set `ccd_count = 0`. 