### PR TITLE
Use setuptools_scm for single-source version

### DIFF
--- a/.git_archival.txt
+++ b/.git_archival.txt
@@ -1,0 +1,1 @@
+ref-names: $Format:%D$

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+.git_archival.txt  export-subst

--- a/Chandra/cmd_states/__init__.py
+++ b/Chandra/cmd_states/__init__.py
@@ -1,8 +1,9 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import ska_helpers
 from .cmd_states import *
 from .get_cmd_states import fetch_states
 
-__version__ = '3.15'
+__version__ = ska_helpers.get_version(__package__)
 
 
 def test(*args, **kwargs):

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,6 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
 from setuptools import setup
 
-from Chandra.cmd_states import __version__
 try:
     from testr.setup_helper import cmdclass
 except ImportError:
@@ -18,7 +17,8 @@ setup(name='Chandra.cmd_states',
                   'Chandra.cmd_states.interrupt_loads',
                   'Chandra.cmd_states.add_nonload_cmds',
                   ],
-      version=__version__,
+      use_scm_version=True,
+      setup_requires=['setuptools_scm', 'setuptools_scm_git_archive'],
       zip_safe=False,
       packages=['Chandra', 'Chandra.cmd_states', 'Chandra.cmd_states.tests'],
       tests_require=['pytest'],


### PR DESCRIPTION
Implementation of setuptools_scm usage as described in skare3/issues/240