### PR TITLE
WIP: Add dither disable to nsm cmd set

### DIFF
--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -794,8 +794,11 @@ def cmd_set(name, *args):
 
     def nsm():
         return (dict(cmd='COMMAND_SW',
-                     tlmsid='AONSMSAF'),
-                )
+                     tlmsid='AONSMSAF',
+                     dur=1.025),
+                dict(cmd='COMMAND_SW',
+                     tlmsid='AODSDITH'))
+
 
     cmd_sets = dict(manvr=manvr, scs107=scs107, nsm=nsm, obsid=obsid,
                     acis=acis, aciscti=aciscti)


### PR DESCRIPTION
## Description

This is untested.  I think if we don't want to do backports to Ska2 that we need to test and update the scs107 response to be Ska3 .


## Testing

- [ ] Passes unit tests on MacOS, linux, Windows (at least one required)
- [ ] Functional testing

Fixes #