### PR TITLE
Ignore warnings

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,4 @@
 filterwarnings =
     # See https://github.com/numpy/numpy/issues/11788 for why this is benign
     ignore:numpy.ufunc size changed:RuntimeWarning
+    ignore:parse functions are required to provide a named argument:PendingDeprecationWarning

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+filterwarnings =
+    # See https://github.com/numpy/numpy/issues/11788 for why this is benign
+    ignore:numpy.ufunc size changed:RuntimeWarning


### PR DESCRIPTION
## Description

Ignore two warnings that are from upstream and are not relevant to this package.

## Testing

- [x] Passes unit tests on MacOS (shiny)
- [x] Passes unit tests on MacOS (flight)
- [N/A] Functional testing
