### PR TITLE
Updates for shiny

### DIFF
--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -474,7 +474,7 @@ def _tl_to_bs_cmds(tl_cmds, tl_id, db):
 def get_cmds(datestart='1998:001:00:00:00.000',
              datestop='2099:001:00:00:00.000',
              db=None, update_db=None, timeline_loads=None,
-             mp_dir='/data/mpcrit1/mplogs'):
+             mp_dir=f'{os.environ["SKA"]}/data/mpcrit1/mplogs'):
     """Get all commands with ``datestart`` < date <= ``datestop`` using DBI
     object ``db``.  This includes both commands already in the database and new
     commands.  If ``update_db`` is True then update the database cmds table
@@ -716,7 +716,7 @@ def generate_cmds(time, cmd_set):
 
 
 def cmd_set(name, *args):
-    """
+    r"""
     Return a predefined cmd_set ``name`` generated with \*args.
 
     :param name: cmd set name (manvr|scs107|nsm)

--- a/Chandra/cmd_states/get_cmd_states.py
+++ b/Chandra/cmd_states/get_cmd_states.py
@@ -113,7 +113,7 @@ def fetch_states(start=None, stop=None, vals=None, allow_identical=False,
 
       # Get commanded states using the default HDF5 table
       >>> from Chandra.cmd_states import fetch_states
-      >>> states = fetch_states('2011:100', '2011:101', vals=['obsid', 'simpos'])
+      >>> states = fetch_states('2011:100:12:00:00', '2011:101:12:00:00', vals=['obsid', 'simpos'])
       >>> states[['datestart', 'datestop', 'obsid', 'simpos']]
       array([('2011:100:11:53:12.378', '2011:101:00:23:01.434', 13255, 75624),
              ('2011:101:00:23:01.434', '2011:101:00:26:01.434', 13255, 91272),
@@ -121,7 +121,7 @@ def fetch_states(start=None, stop=None, vals=None, allow_identical=False,
             dtype=[('datestart', '|S21'), ('datestop', '|S21'), ('obsid', '<i8'), ('simpos', '<i8')])
 
       # Get same states from Sybase (25 times slower)
-      >>> states2 = fetch_states('2011:100', '2011:101', vals=['obsid', 'simpos'], dbi='sybase')
+      >>> states2 = fetch_states('2011:100:12:00:00', '2011:101:12:00:00', vals=['obsid', 'simpos'], dbi='sybase')
       >>> states2 == states
       array([ True,  True,  True], dtype=bool)
 

--- a/tests/otg_telem.py
+++ b/tests/otg_telem.py
@@ -22,12 +22,12 @@ logging.basicConfig(level=10,
                     format='%(message)s',
                     stream=sys.stdout)
 
-tlm = fetch.MSIDset(['4HPOSARO', '4LPOSARO'], '2009:010', '2010:210', stat='5min')
+tlm = fetch.MSIDset(['4HPOSARO', '4LPOSARO'], '2009:010:12:00:00', '2010:210:12:00:00', stat='5min')
 
 # db = Ska.DBI.DBI(dbi='sybase')
 
-datestart = DateTime('2008:360').date
-datestop = DateTime('2010:220').date
+datestart = DateTime('2008:360:12:00:00').date
+datestop = DateTime('2010:220:12:00:00').date
 
 if 1 or 'states' not in globals():
     print 'Getting states'


### PR DESCRIPTION
## Description

More updates to pass tests on shiny with no warnings. This also migrates to the more generic convention of expecting SOT MP files at `$SKA/data/mpcrit1/mplogs/...`.  Then one can use links and sshfs to make that available.

## Testing

- [x] Passes unit tests on MacOS (shiny)
- [x] Passes unit tests on MacOS (flight)
- [N/A] Functional testing
