### PR TITLE
Ignore Ska.ParseCM warning in testing

### DIFF
--- a/Chandra/cmd_states/tests/test_get_cmd_states.py
+++ b/Chandra/cmd_states/tests/test_get_cmd_states.py
@@ -3,8 +3,8 @@ import os
 import sys
 from pathlib import Path
 from io import StringIO
-import pytest
 
+import pytest
 import numpy as np
 from astropy.io import ascii
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -3,3 +3,4 @@ filterwarnings =
     # See https://github.com/numpy/numpy/issues/11788 for why this is benign
     ignore:numpy.ufunc size changed:RuntimeWarning
     ignore:parse functions are required to provide a named argument:PendingDeprecationWarning
+    ignore:Ska.ParseCM is deprecated, use parse_cm instead:FutureWarning


### PR DESCRIPTION
## Description

Trivial change to ignore the FutureWarning from importing Ska.ParseCM when running `python setup.py test`.

## Testing

- [x] Passes unit tests on MacOS
- [N/A] Functional testing
