### PR TITLE
Warn on use of sybase to get cmd_states

### DIFF
--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -409,9 +409,9 @@ def get_state0(date=None, db=None, date_margin=10, datepar='datestop'):
     :rtype: dict
     """
     if db is None:
-        db = Ska.DBI.DBI(dbi='sybase', server='sybase', user='aca_read',
-                         database='aca')
-
+        db = Ska.DBI.DBI(dbi='sqlite',
+                         server=os.path.join(
+                             os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3'))
     if date is not None:
         date = DateTime(date).date
 

--- a/Chandra/cmd_states/get_cmd_states.py
+++ b/Chandra/cmd_states/get_cmd_states.py
@@ -8,6 +8,7 @@ import argparse
 import os
 import re
 import six
+import warnings
 
 import numpy as np
 from Chandra.Time import DateTime
@@ -86,6 +87,8 @@ def get_sql_states(start, stop, dbi, server, user, database):
     """
     import Ska.DBI
 
+    if dbi == 'sybase':
+        warnings.warn('sybase cmd_states are no longer supported', FutureWarning)
     if dbi == 'sqlite' and server is None:
         server = os.path.join(SKA, 'data', 'cmd_states', 'cmd_states.db3')
 

--- a/Chandra/cmd_states/tests/test_get_cmd_states.py
+++ b/Chandra/cmd_states/tests/test_get_cmd_states.py
@@ -86,7 +86,7 @@ def test_acis_power_cmds():
     assert all_off["fep_count"] == 0
     assert all_off["vid_board"] == 0
     server = os.path.join(os.environ['SKA'], 'data', 'cmd_states', 'cmd_states.db3')
-    db = Ska.DBI.DBI(dbi="sqlite", server=server, user='aca_read', database='aca')
+    db = Ska.DBI.DBI(dbi="sqlite", server=server)
     state0 = get_state0("2017:359:13:37:50", db=db)
     cmds = get_cmds("2017:359:13:37:50", "2017:360:00:46:00", db=db)
     states = get_states(state0, cmds)


### PR DESCRIPTION
## Description

Warn on use of sybase to get cmd_states

This leaves all of the code in place to work with the sybase dbi.

## Testing

- [x] Passes unit tests on linux (sybase was already removed from the testing)
- [x] Functional testing (shows FutureWarning when run with db set to sybase)

Fixes #53  (if a warning is sufficient)