### PR TITLE
Set interrupt_loads to shorten timelines only as short as zero length

### DIFF
--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -840,9 +840,16 @@ def interrupt_loads(datestop, db, observing_only=False, current_only=False):
         logging.info("UPDATE timelines SET datestop='%s' where id=%d ;"
                      % (tl['datestop'], tl['id']))
 
+    # For timelines in this set that start before the interrupt (datestop)
+    # time, interrupt at datestop.  For the ones after the interrupt time,
+    # set datestop=datestart so they just have zero length.
     for tl in timelines:
+        if tl['datestart'] < datestop:
+            interrupt_time = datestop
+        else:
+            interrupt_time = tl['datestart']
         update = ("UPDATE timelines SET datestop='%s' where id=%d"
-                  % (datestop, tl['id']))
+                  % (interrupt_time, tl['id']))
         db.execute(update)
 
 


### PR DESCRIPTION
## Description

Set interrupt_loads to shorten timelines only as short as zero length.  This sets the timelines to not have negative duration.
This should prevent recurrence of https://github.com/sot/timelines/issues/24 without any side-effects.

## Testing

- [x] Passes unit tests on linux (though those aren't really comprehensive tests)
- [x] Functional testing

I tested just with sqlite and confirmed expected datestop values by eye, with an interrupt time set to '2020:266:14:48:29.000' in full interrupt and observing_only modes.

```
Current real database

sqlite> select * from timelines where datestart > '2020:260';
426104399|426104272|/2020/SEP1220/oflsa/|2020:261:23:14:59.959|2020:264:06:44:08.275|0|0|0
426104400|426104273|/2020/SEP1220/oflsa/|2020:261:23:14:59.959|2020:264:06:44:08.275|0|0|0
426104401|426104274|/2020/SEP2120/oflsa/|2020:264:06:42:00.000|2020:267:05:04:01.816|0|0|0
426104402|426104275|/2020/SEP2120/oflsa/|2020:264:06:42:00.000|2020:267:05:04:01.816|0|0|0
426104403|426104276|/2020/SEP2120/oflsa/|2020:267:05:46:01.272|2020:270:03:15:02.313|0|0|0
426104404|426104277|/2020/SEP2120/oflsa/|2020:267:05:46:01.272|2020:270:03:15:02.313|0|0|0
426104405|426104278|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:272:05:01:47.549|0|0|0
426104406|426104279|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:272:05:01:47.549|0|0|0


Doing a full interrupt

sqlite> select * from timelines where datestart > '2020:260';
426104399|426104272|/2020/SEP1220/oflsa/|2020:261:23:14:59.959|2020:264:06:44:08.275|0|0|0
426104400|426104273|/2020/SEP1220/oflsa/|2020:261:23:14:59.959|2020:264:06:44:08.275|0|0|0
426104401|426104274|/2020/SEP2120/oflsa/|2020:264:06:42:00.000|2020:266:14:48:29.000|0|0|0
426104402|426104275|/2020/SEP2120/oflsa/|2020:264:06:42:00.000|2020:266:14:48:29.000|0|0|0
426104403|426104276|/2020/SEP2120/oflsa/|2020:267:05:46:01.272|2020:267:05:46:01.272|0|0|0
426104404|426104277|/2020/SEP2120/oflsa/|2020:267:05:46:01.272|2020:267:05:46:01.272|0|0|0
426104405|426104278|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:270:08:32:29.334|0|0|0
426104406|426104279|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:270:08:32:29.334|0|0|0

Observing-only

sqlite> select * from timelines where datestart > '2020:260';
426104399|426104272|/2020/SEP1220/oflsa/|2020:261:23:14:59.959|2020:264:06:44:08.275|0|0|0
426104400|426104273|/2020/SEP1220/oflsa/|2020:261:23:14:59.959|2020:264:06:44:08.275|0|0|0
426104401|426104274|/2020/SEP2120/oflsa/|2020:264:06:42:00.000|2020:267:05:04:01.816|0|0|0
426104402|426104275|/2020/SEP2120/oflsa/|2020:264:06:42:00.000|2020:266:14:48:29.000|0|0|0
426104403|426104276|/2020/SEP2120/oflsa/|2020:267:05:46:01.272|2020:270:03:15:02.313|0|0|0
426104404|426104277|/2020/SEP2120/oflsa/|2020:267:05:46:01.272|2020:267:05:46:01.272|0|0|0
426104405|426104278|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:272:05:01:47.549|0|0|0
426104406|426104279|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:270:08:32:29.334|0|0|0

```

Fixes https://github.com/sot/timelines/issues/24