### PR TITLE
Don't shorten timelines all the way to neg durations

### DIFF
--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -840,9 +840,16 @@ def interrupt_loads(datestop, db, observing_only=False, current_only=False):
         logging.info("UPDATE timelines SET datestop='%s' where id=%d ;"
                      % (tl['datestop'], tl['id']))
 
+    # For timelines in this set that start before the interrupt (datestop)
+    # time, interrupt at datestop.  For the ones after the interrupt time,
+    # set datestop=datestart so they just have zero length.
     for tl in timelines:
+        if tl['datestart'] < datestop:
+            interrupt_time = datestop
+        else:
+            interrupt_time = tl['datestart']
         update = ("UPDATE timelines SET datestop='%s' where id=%d"
-                  % (datestop, tl['id']))
+                  % (interrupt_time, tl['id']))
         db.execute(update)
 
 


### PR DESCRIPTION
## Description

Redo #61 as a backport/cherry-pick to the ska2 version (which was 3.14.2)

## Testing

- [x] Passes unit tests on linux in ska2
- [x] Functional testing (two case tests below)


```
sqlite> select * from timelines where datestart > '2020:270';
426104405|426104278|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:272:05:01:47.549|0|0|0
426104406|426104279|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:272:05:01:47.549|0|0|0
426104407|426104280|/2020/SEP2820/oflsc/|2020:272:04:59:00.000|2020:275:01:25:35.000|0|0|0
426104408|426104281|/2020/SEP2820/oflsc/|2020:272:04:59:00.000|2020:275:01:25:35.000|0|0|0
426104409|426104282|/2020/SEP2820/oflsc/|2020:275:01:53:41.872|2020:278:17:55:25.599|0|0|0
426104410|426104283|/2020/SEP2820/oflsc/|2020:275:01:53:41.872|2020:278:17:55:25.599|0|0|0
426104411|426104284|/2020/OCT0520/oflsa/|2020:278:17:52:25.599|2020:282:13:45:02.313|0|0|0
426104412|426104285|/2020/OCT0520/oflsa/|2020:278:17:52:25.599|2020:282:13:45:02.313|0|0|0
426104413|426104286|/2020/OCT0520/oflsa/|2020:282:16:52:25.557|2020:285:10:29:15.023|0|0|0
426104414|426104287|/2020/OCT0520/oflsa/|2020:282:16:52:25.557|2020:285:10:29:15.023|0|0|0

Full interrupt

In [5]: db = Ska.DBI.DBI(dbi='sqlite', server='cmd_states.db3')

In [6]: Chandra.cmd_states.interrupt_loads('2020:274:12:00:00.000', db)

sqlite> select * from timelines where datestart > '2020:270';
426104405|426104278|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:272:05:01:47.549|0|0|0
426104406|426104279|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:272:05:01:47.549|0|0|0
426104407|426104280|/2020/SEP2820/oflsc/|2020:272:04:59:00.000|2020:274:12:00:00.000|0|0|0
426104408|426104281|/2020/SEP2820/oflsc/|2020:272:04:59:00.000|2020:274:12:00:00.000|0|0|0
426104409|426104282|/2020/SEP2820/oflsc/|2020:275:01:53:41.872|2020:275:01:53:41.872|0|0|0
426104410|426104283|/2020/SEP2820/oflsc/|2020:275:01:53:41.872|2020:275:01:53:41.872|0|0|0
426104411|426104284|/2020/OCT0520/oflsa/|2020:278:17:52:25.599|2020:278:17:52:25.599|0|0|0
426104412|426104285|/2020/OCT0520/oflsa/|2020:278:17:52:25.599|2020:278:17:52:25.599|0|0|0
426104413|426104286|/2020/OCT0520/oflsa/|2020:282:16:52:25.557|2020:282:16:52:25.557|0|0|0
426104414|426104287|/2020/OCT0520/oflsa/|2020:282:16:52:25.557|2020:282:16:52:25.557|0|0|0

Observing-only interrupt

In [4]: Chandra.cmd_states.interrupt_loads('2020:274:12:00:00.000', db, observing_only=True)

sqlite> select * from timelines where datestart > '2020:270';
426104405|426104278|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:272:05:01:47.549|0|0|0
426104406|426104279|/2020/SEP2120/oflsa/|2020:270:08:32:29.334|2020:272:05:01:47.549|0|0|0
426104407|426104280|/2020/SEP2820/oflsc/|2020:272:04:59:00.000|2020:275:01:25:35.000|0|0|0
426104408|426104281|/2020/SEP2820/oflsc/|2020:272:04:59:00.000|2020:274:12:00:00.000|0|0|0
426104409|426104282|/2020/SEP2820/oflsc/|2020:275:01:53:41.872|2020:278:17:55:25.599|0|0|0
426104410|426104283|/2020/SEP2820/oflsc/|2020:275:01:53:41.872|2020:275:01:53:41.872|0|0|0
426104411|426104284|/2020/OCT0520/oflsa/|2020:278:17:52:25.599|2020:282:13:45:02.313|0|0|0
426104412|426104285|/2020/OCT0520/oflsa/|2020:278:17:52:25.599|2020:278:17:52:25.599|0|0|0
426104413|426104286|/2020/OCT0520/oflsa/|2020:282:16:52:25.557|2020:285:10:29:15.023|0|0|0
426104414|426104287|/2020/OCT0520/oflsa/|2020:282:16:52:25.557|2020:282:16:52:25.557|0|0|0

```

