### PR TITLE
Add dither cmd sets and fix nsm cmd_set, etc

### DIFF
--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -792,13 +792,32 @@ def cmd_set(name, *args):
                      tlmsid='WSPOW00000'),
                 )
 
-    def nsm():
-        return (dict(cmd='COMMAND_SW',
-                     tlmsid='AONSMSAF'),
+    def dith_on():
+        return (dict(dur=1.025),
+                dict(cmd='COMMAND_SW',
+                     tlmsid='AOENDITH',
+                     )
                 )
 
+    def dith_off():
+        return (dict(dur=1.025),
+                dict(cmd='COMMAND_SW',
+                     tlmsid='AODSDITH',
+                     )
+                )
+
+    def nsm():
+        nsm_cmd = dict(cmd='COMMAND_SW',
+                       tlmsid='AONSMSAF')
+        out = ((nsm_cmd,)
+               + scs107()
+               + dith_off()
+               )
+        return out
+
     cmd_sets = dict(manvr=manvr, scs107=scs107, nsm=nsm, obsid=obsid,
-                    acis=acis, aciscti=aciscti)
+                    acis=acis, aciscti=aciscti,
+                    dith_on=dith_on, dith_off=dith_off)
     return cmd_sets[name](*args)
 
 

--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -779,6 +779,13 @@ def cmd_set(name, *args):
 
     def scs107():
         return (dict(dur=1.025),
+                dict(cmd='COMMAND_SW',
+                     dur=1.025,
+                     tlmsid='OORMPDS'),
+                dict(cmd='COMMAND_HW',
+                     dur=1.025,
+                     tlmsid='AFIDP',
+                     msid='AFLCRSET'),
                 dict(cmd='SIMTRANS',
                      params=dict(POS=-99616),
                      dur=65.66),

--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -789,7 +789,7 @@ def cmd_set(name, *args):
                      tlmsid='AA00000000',
                      dur=10.25),
                 dict(cmd='ACISPKT',
-                     tlmsid='WSPOW00000'),
+                     tlmsid='WSPOW0002A'),
                 )
 
     def dith_on():

--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -761,7 +761,7 @@ def cmd_set(name, *args):
                 )
 
     def acis(*args):
-        cmds = [dict(cmd='ACISPKT', tlmsid=tlmsid) for tlmsid in args]
+        cmds = tuple(dict(cmd='ACISPKT', tlmsid=tlmsid) for tlmsid in args)
         return cmds
 
     def aciscti():

--- a/Chandra/cmd_states/tests/test_cmd_sets.py
+++ b/Chandra/cmd_states/tests/test_cmd_sets.py
@@ -27,7 +27,7 @@ def test_cmd_sets2():
 
 
 def test_cmd_sets3():
-    cmds = cmd_set('manvr', 0, 1, 0, 0)
+    cmds = cmd_set('manvr', 0, 0, 0, 1)
     exp = ({'cmd': 'COMMAND_SW',
             'dur': 0.25625,
             'msid': 'AONMMODE',
@@ -35,7 +35,7 @@ def test_cmd_sets3():
            {'cmd': 'COMMAND_SW', 'dur': 4.1, 'msid': 'AONM2NPE', 'tlmsid': 'AONM2NPE'},
            {'cmd': 'MP_TARGQUAT',
             'dur': 5.894,
-            'params': {'Q1': 0.0, 'Q2': 1.0, 'Q3': 0.0, 'Q4': 0.0},
+            'params': {'Q1': 0.0, 'Q2': 0.0, 'Q3': 0.0, 'Q4': 1.0},
             'tlmsid': 'AOUPTARQ'},
            {'cmd': 'COMMAND_SW', 'msid': 'AOMANUVR', 'tlmsid': 'AOMANUVR'})
     assert cmds == exp

--- a/Chandra/cmd_states/tests/test_cmd_sets.py
+++ b/Chandra/cmd_states/tests/test_cmd_sets.py
@@ -9,7 +9,7 @@ def test_cmd_sets1():
            {'cmd': 'SIMTRANS', 'dur': 65.66, 'params': {'POS': -99616}},
            {'cmd': 'ACISPKT', 'dur': 1.025, 'tlmsid': 'AA00000000'},
            {'cmd': 'ACISPKT', 'dur': 10.25, 'tlmsid': 'AA00000000'},
-           {'cmd': 'ACISPKT', 'tlmsid': 'WSPOW00000'})
+           {'cmd': 'ACISPKT', 'tlmsid': 'WSPOW0002A'})
     assert cmds == exp
 
 
@@ -20,7 +20,7 @@ def test_cmd_sets2():
            {'cmd': 'SIMTRANS', 'dur': 65.66, 'params': {'POS': -99616}},
            {'cmd': 'ACISPKT', 'dur': 1.025, 'tlmsid': 'AA00000000'},
            {'cmd': 'ACISPKT', 'dur': 10.25, 'tlmsid': 'AA00000000'},
-           {'cmd': 'ACISPKT', 'tlmsid': 'WSPOW00000'},
+           {'cmd': 'ACISPKT', 'tlmsid': 'WSPOW0002A'},
            {'dur': 1.025},
            {'cmd': 'COMMAND_SW', 'tlmsid': 'AODSDITH'})
     assert cmds == exp

--- a/Chandra/cmd_states/tests/test_cmd_sets.py
+++ b/Chandra/cmd_states/tests/test_cmd_sets.py
@@ -1,0 +1,66 @@
+# Licensed under a 3-clause BSD style license - see LICENSE.rst
+
+from Chandra.cmd_states import cmd_set
+
+
+def test_cmd_sets1():
+    cmds = cmd_set('scs107')
+    exp = ({'dur': 1.025},
+           {'cmd': 'SIMTRANS', 'dur': 65.66, 'params': {'POS': -99616}},
+           {'cmd': 'ACISPKT', 'dur': 1.025, 'tlmsid': 'AA00000000'},
+           {'cmd': 'ACISPKT', 'dur': 10.25, 'tlmsid': 'AA00000000'},
+           {'cmd': 'ACISPKT', 'tlmsid': 'WSPOW00000'})
+    assert cmds == exp
+
+
+def test_cmd_sets2():
+    cmds = cmd_set('nsm')
+    exp = ({'cmd': 'COMMAND_SW', 'tlmsid': 'AONSMSAF'},
+           {'dur': 1.025},
+           {'cmd': 'SIMTRANS', 'dur': 65.66, 'params': {'POS': -99616}},
+           {'cmd': 'ACISPKT', 'dur': 1.025, 'tlmsid': 'AA00000000'},
+           {'cmd': 'ACISPKT', 'dur': 10.25, 'tlmsid': 'AA00000000'},
+           {'cmd': 'ACISPKT', 'tlmsid': 'WSPOW00000'},
+           {'dur': 1.025},
+           {'cmd': 'COMMAND_SW', 'tlmsid': 'AODSDITH'})
+    assert cmds == exp
+
+
+def test_cmd_sets3():
+    cmds = cmd_set('manvr', 0, 1, 0, 0)
+    exp = ({'cmd': 'COMMAND_SW',
+            'dur': 0.25625,
+            'msid': 'AONMMODE',
+            'tlmsid': 'AONMMODE'},
+           {'cmd': 'COMMAND_SW', 'dur': 4.1, 'msid': 'AONM2NPE', 'tlmsid': 'AONM2NPE'},
+           {'cmd': 'MP_TARGQUAT',
+            'dur': 5.894,
+            'params': {'Q1': 0.0, 'Q2': 1.0, 'Q3': 0.0, 'Q4': 0.0},
+            'tlmsid': 'AOUPTARQ'},
+           {'cmd': 'COMMAND_SW', 'msid': 'AOMANUVR', 'tlmsid': 'AOMANUVR'})
+    assert cmds == exp
+
+
+def test_cmd_sets4():
+    cmds = cmd_set('obsid', 30000)
+    exp = ({'cmd': 'MP_OBSID', 'params': {'ID': 30000}},)
+    assert cmds == exp
+
+
+def test_cmd_sets5():
+    cmds = cmd_set('acis', 'XTZ0000005', 'WSPOW0CF3F')
+    exp = ({'cmd': 'ACISPKT', 'tlmsid': 'XTZ0000005'},
+           {'cmd': 'ACISPKT', 'tlmsid': 'WSPOW0CF3F'})
+    assert cmds == exp
+
+
+def test_cmd_sets6():
+    cmds = cmd_set('dith_on')
+    exp = ({'dur': 1.025}, {'cmd': 'COMMAND_SW', 'tlmsid': 'AOENDITH'})
+    assert cmds == exp
+
+
+def test_cmd_sets7():
+    cmds = cmd_set('dith_off')
+    exp = ({'dur': 1.025}, {'cmd': 'COMMAND_SW', 'tlmsid': 'AODSDITH'})
+    assert cmds == exp

--- a/Chandra/cmd_states/tests/test_cmd_sets.py
+++ b/Chandra/cmd_states/tests/test_cmd_sets.py
@@ -2,10 +2,13 @@
 
 from Chandra.cmd_states import cmd_set
 
+# COMMAND_HW       | TLMSID= AFIDP, HEX= 6480005, MSID= AFLCRSET
 
 def test_cmd_sets1():
     cmds = cmd_set('scs107')
     exp = ({'dur': 1.025},
+           {'cmd': 'COMMAND_SW', 'dur': 1.025, 'tlmsid': 'OORMPDS'},
+           {'cmd': 'COMMAND_HW', 'dur': 1.025, 'tlmsid': 'AFIDP', 'msid': 'AFLCRSET'},
            {'cmd': 'SIMTRANS', 'dur': 65.66, 'params': {'POS': -99616}},
            {'cmd': 'ACISPKT', 'dur': 1.025, 'tlmsid': 'AA00000000'},
            {'cmd': 'ACISPKT', 'dur': 10.25, 'tlmsid': 'AA00000000'},
@@ -17,6 +20,8 @@ def test_cmd_sets2():
     cmds = cmd_set('nsm')
     exp = ({'cmd': 'COMMAND_SW', 'tlmsid': 'AONSMSAF'},
            {'dur': 1.025},
+           {'cmd': 'COMMAND_SW', 'dur': 1.025, 'tlmsid': 'OORMPDS'},
+           {'cmd': 'COMMAND_HW', 'dur': 1.025, 'tlmsid': 'AFIDP', 'msid': 'AFLCRSET'},
            {'cmd': 'SIMTRANS', 'dur': 65.66, 'params': {'POS': -99616}},
            {'cmd': 'ACISPKT', 'dur': 1.025, 'tlmsid': 'AA00000000'},
            {'cmd': 'ACISPKT', 'dur': 10.25, 'tlmsid': 'AA00000000'},


### PR DESCRIPTION
## Description

This adds `dith_on` and `dith_off` command sets. It also updates the `nsm` command set to include `scs107` and `dith_off`.

## Testing

- [x] Passes unit tests on MacOS (new tests)
- [n/a] Functional testing

Fixes #50