### PR TITLE
Ska2: add dither cmd sets, fix nsm cmd set, and update scs107 cmd set

### DIFF
--- a/Chandra/cmd_states/cmd_states.py
+++ b/Chandra/cmd_states/cmd_states.py
@@ -779,6 +779,13 @@ def cmd_set(name, *args):
 
     def scs107():
         return (dict(dur=1.025),
+                dict(cmd='COMMAND_SW',
+                     dur=1.025,
+                     tlmsid='OORMPDS'),
+                dict(cmd='COMMAND_HW',
+                     dur=1.025,
+                     tlmsid='AFIDP',
+                     msid='AFLCRSET'),
                 dict(cmd='SIMTRANS',
                      params=dict(POS=-99616),
                      dur=65.66),

--- a/Chandra/cmd_states/tests/test_cmd_sets.py
+++ b/Chandra/cmd_states/tests/test_cmd_sets.py
@@ -2,10 +2,13 @@
 
 from Chandra.cmd_states import cmd_set
 
+# COMMAND_HW       | TLMSID= AFIDP, HEX= 6480005, MSID= AFLCRSET
 
 def test_cmd_sets1():
     cmds = cmd_set('scs107')
     exp = ({'dur': 1.025},
+           {'cmd': 'COMMAND_SW', 'dur': 1.025, 'tlmsid': 'OORMPDS'},
+           {'cmd': 'COMMAND_HW', 'dur': 1.025, 'tlmsid': 'AFIDP', 'msid': 'AFLCRSET'},
            {'cmd': 'SIMTRANS', 'dur': 65.66, 'params': {'POS': -99616}},
            {'cmd': 'ACISPKT', 'dur': 1.025, 'tlmsid': 'AA00000000'},
            {'cmd': 'ACISPKT', 'dur': 10.25, 'tlmsid': 'AA00000000'},
@@ -17,6 +20,8 @@ def test_cmd_sets2():
     cmds = cmd_set('nsm')
     exp = ({'cmd': 'COMMAND_SW', 'tlmsid': 'AONSMSAF'},
            {'dur': 1.025},
+           {'cmd': 'COMMAND_SW', 'dur': 1.025, 'tlmsid': 'OORMPDS'},
+           {'cmd': 'COMMAND_HW', 'dur': 1.025, 'tlmsid': 'AFIDP', 'msid': 'AFLCRSET'},
            {'cmd': 'SIMTRANS', 'dur': 65.66, 'params': {'POS': -99616}},
            {'cmd': 'ACISPKT', 'dur': 1.025, 'tlmsid': 'AA00000000'},
            {'cmd': 'ACISPKT', 'dur': 10.25, 'tlmsid': 'AA00000000'},


### PR DESCRIPTION
## Description

Same as #64 but for Ska2. 

Doing another backport is not ideal but we do not have any other timely choices. Getting these state updates in place is time critical to be prepared for the next safing action.

## Testing

- [x] Passes unit tests on Ska2 linux (kady)
- [n/a] Functional testing

## Deployment

We will discuss on Slack how to appropriately deploy this.

Fixes #37