### PR TITLE
Discontinue support for chandra_cmd_states

### DIFF
--- a/chandra_cmd_states/__init__.py
+++ b/chandra_cmd_states/__init__.py
@@ -1,4 +1,23 @@
 # Licensed under a 3-clause BSD style license - see LICENSE.rst
+import os
+import warnings
+
+message_warn = (
+    "\n"
+    "The chandra_cmd_states package is no longer supported and is replaced\n"
+    "by kadi.commands.states. Please update your code accordingly.\n"
+)
+message_error = (
+    "\n"
+    "To temporarily continue using this package set the environment variable\n"
+    "SKA_ALLOW_DISCONTINUED_PACKAGES=1"
+)
+
+if os.environ.get("SKA_ALLOW_DISCONTINUED_PACKAGES") == "1":
+    warnings.warn(message_warn, FutureWarning)
+else:
+    raise RuntimeError(message_warn + message_error)
+
 import ska_helpers
 from .cmd_states import *
 from .get_cmd_states import fetch_states

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,24 +1,16 @@
 Chandra commanded states database
 ==================================
 
+.. Warning:: the commanded states database and package described here is
+    **discontinued and no longer supported**. Instead use the
+   `Kadi commands and states
+   package <http://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/kadi/commands_states.html>`_.
+
 This suite of tools provides the interface for creation and maintenance of the
 Chandra commanded states database. This database provides the commanded state
 of Chandra from 2002 through to the end of all approved command loads that are
 ingested to the OFLS database.  The database thus contains both the definitive
 state and a predictive state at any time.
-
-.. Warning:: Use of the commanded states database described here is deprecated
-   in favor of the `Kadi commands and states
-   package <http://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/kadi/commands_states.html>`_.
-   The replacement for the :func:`~chandra_cmd_states.fetch_states` function is described
-   in the `Chandra states and continuity
-   <http://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/kadi/commands_states.html#states>`_
-   section which makes use of the `get_states
-   <http://cxc.cfa.harvard.edu/mta/ASPECT/tool_doc/kadi/api.html#kadi.commands.states.get_states>`_
-   function.
-
-   The commanded states database is still being maintained, but no new development
-   is expected.
 
 A commanded state is an interval of time over which certain parameters of
 interest (obsid, SIM-Z position, commanded attitude, ACIS power configuration,


### PR DESCRIPTION
## Description

This addresses one action in https://github.com/sot/kadi/issues/230.

## Interface impacts
<!-- API changes, file format updates, coordination of changes with the community. -->
Importing package raises an exception unless `SKA_ALLOW_DISCONTINUED_PACKAGES=1`.

## Testing
<!-- If relevant describe any special setup for testing. -->

### Unit tests
<!-- At least one of these must be checked if unit tests exist. DELETE the unchecked/untested options. -->
No testing required for discontinued package.

### Functional tests

#### Importing package fails without env var
```
(ska3) ➜  cmd_states git:(master) ✗ ipython
Python 3.10.8 | packaged by conda-forge | (main, Nov 22 2022, 08:27:35) [Clang 14.0.6 ]
Type 'copyright', 'credits' or 'license' for more information
IPython 8.8.0 -- An enhanced Interactive Python. Type '?' for help.

In [1]: import chandra_cmd_states
/Users/aldcroft/miniconda3/envs/ska3/lib/python3.10/site-packages/Ska/ParseCM/ParseCM.py:8: FutureWarning: ska_parsecm is deprecated, use parse_cm instead
  warnings.warn('ska_parsecm is deprecated, use parse_cm instead', FutureWarning)
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[1], line 1
----> 1 import chandra_cmd_states

File ~/git/cmd_states/chandra_cmd_states/__init__.py:23
     21     warnings.warn(message_warn, FutureWarning)
     22 else:
---> 23     raise RuntimeError(message_warn + message_error)
     25 __version__ = ska_helpers.get_version("chandra_cmd_states")
     28 def test(*args, **kwargs):

RuntimeError: 
The chandra_cmd_states package is no longer supported and is replaced
by kadi.commands.states. Please update your code accordingly.

To temporarily continue using this package set the environment variable
SKA_ALLOW_DISCONTINUED_PACKAGES=1

In [2]: import chandra_cmd_states
---------------------------------------------------------------------------
RuntimeError                              Traceback (most recent call last)
Cell In[2], line 1
----> 1 import chandra_cmd_states

File ~/git/cmd_states/chandra_cmd_states/__init__.py:23
     21     warnings.warn(message_warn, FutureWarning)
     22 else:
---> 23     raise RuntimeError(message_warn + message_error)
     25 __version__ = ska_helpers.get_version("chandra_cmd_states")
     28 def test(*args, **kwargs):

RuntimeError: 
The chandra_cmd_states package is no longer supported and is replaced
by kadi.commands.states. Please update your code accordingly.

To temporarily continue using this package set the environment variable
SKA_ALLOW_DISCONTINUED_PACKAGES=1
```
#### Setting env var allows import with a FutureWarning
```
In [3]: import os

In [4]: os.environ["SKA_ALLOW_DISCONTINUED_PACKAGES"] = "1"

In [5]: import chandra_cmd_states
/Users/aldcroft/git/cmd_states/chandra_cmd_states/__init__.py:21: FutureWarning: 
The chandra_cmd_states package is no longer supported and is replaced
by kadi.commands.states. Please update your code accordingly.

  warnings.warn(message_warn, FutureWarning)

In [6]: import chandra_cmd_states

In [7]:                                                                                                                                                      
```
